### PR TITLE
Add name attribute on game

### DIFF
--- a/lib/igdb/representers/game_representer.rb
+++ b/lib/igdb/representers/game_representer.rb
@@ -1,6 +1,7 @@
 module Igdb::GameRepresenter
   include Igdb::BaseRepresenter
 
+  property :name # The game's title.
   property :summary # Not documented in V1 API
   property :storyline
   property :collection


### PR DESCRIPTION
- IGDB API provides game name, but wrapper did not
- Allow user to access game title